### PR TITLE
distance optimize

### DIFF
--- a/ranker_bench_test.go
+++ b/ranker_bench_test.go
@@ -1,0 +1,82 @@
+package deeply //nolint:testpackage
+
+import "testing"
+
+func BenchmarkDistance_SmallASCII(b *testing.B) {
+	s1 := "kitten"
+	s2 := "sitting"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		distance(s1, s2)
+	}
+}
+
+func BenchmarkDistance_SmallUnicode(b *testing.B) {
+	s1 := "kø̃tten" // Norwegian/Danish characters
+	s2 := "sø̃tting"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		distance(s1, s2)
+	}
+}
+
+func BenchmarkDistance_LargeASCII(b *testing.B) {
+	s1 := "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"
+	s2 := "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua changed"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		distance(s1, s2)
+	}
+}
+
+func BenchmarkDistance_LargeUnicode(b *testing.B) {
+	s1 := "Lørém ípsüm dölör sít ämét cönsectétür ädïpïscïng élït séd dö èïüsdöd tëmpör ïncïdïdûnt üt läböre ét dölöre mågnä älïqüä"
+	s2 := "Lørém ípsüm dölör sít ämét cönsectétür ädïpïscïng élït séd dö èïüsdöd tëmpör ïncïdïdûnt üt läböre ét dölöre mågnä älïqüä chängéd"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		distance(s1, s2)
+	}
+}
+
+func BenchmarkDistance_IdenticalStrings(b *testing.B) {
+	s := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		distance(s, s)
+	}
+}
+
+func BenchmarkDistance_EmptyStrings(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		distance("", "")
+	}
+}
+
+func BenchmarkDistance_OneEmpty(b *testing.B) {
+	s := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		distance(s, "")
+	}
+}


### PR DESCRIPTION
### Benchmark Comparison

#### Key Changes:
1. **Small Inputs**:
   - `SmallASCII`: Slightly slower (137.1 ns → 145.2 ns).
   - `SmallUnicode`: Slower (192.1 ns → 242.1 ns), added allocations (0 B/op → 64 B/op).

2. **Large Inputs**:
   - `LargeASCII`: Slightly faster (47575 ns → 46160 ns), reduced allocations (2016 B/op → 1024 B/op).
   - `LargeUnicode`: No significant change.

3. **Edge Cases**:
   - `IdenticalStrings`, `EmptyStrings`, `OneEmpty`: Dramatically faster (ns → ~2 ns), no allocations.

#### Summary:
- **Gains**: Major speedups and zero allocations for edge cases.
- **Losses**: Minor regressions in small inputs, especially Unicode.
- **Trade-offs**: Optimizations favor edge cases but slightly impact small inputs.

before:
```
➜  deeply git:(master) ✗ go test -bench .
goos: darwin
goarch: arm64
pkg: github.com/gripmock/deeply
cpu: Apple M1 Pro
BenchmarkDistance_SmallASCII-8           7784780               137.1 ns/op             0 B/op          0 allocs/op
BenchmarkDistance_SmallUnicode-8         6317986               192.1 ns/op             0 B/op          0 allocs/op
BenchmarkDistance_LargeASCII-8             25010             47575 ns/op            2016 B/op          3 allocs/op
BenchmarkDistance_LargeUnicode-8           24993             47875 ns/op            2016 B/op          3 allocs/op
BenchmarkDistance_IdenticalStrings-8       92086             12959 ns/op             512 B/op          2 allocs/op
BenchmarkDistance_EmptyStrings-8        66816074                17.91 ns/op            0 B/op          0 allocs/op
BenchmarkDistance_OneEmpty-8             9258082               123.5 ns/op           256 B/op          1 allocs/op
PASS
ok      github.com/gripmock/deeply      10.129s
```

after:
```
➜  deeply git:(optimize) ✗ go test -bench .
goos: darwin
goarch: arm64
pkg: github.com/gripmock/deeply
cpu: Apple M1 Pro
BenchmarkDistance_SmallASCII-8           7686594               145.2 ns/op             0 B/op          0 allocs/op
BenchmarkDistance_SmallUnicode-8         5010283               242.1 ns/op            64 B/op          1 allocs/op
BenchmarkDistance_LargeASCII-8             25712             46160 ns/op            1024 B/op          1 allocs/op
BenchmarkDistance_LargeUnicode-8           25251             47510 ns/op            2016 B/op          3 allocs/op
BenchmarkDistance_IdenticalStrings-8    478831730                2.495 ns/op           0 B/op          0 allocs/op
BenchmarkDistance_EmptyStrings-8        479017215                2.529 ns/op           0 B/op          0 allocs/op
BenchmarkDistance_OneEmpty-8            580798672                2.058 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/gripmock/deeply      10.968s
```